### PR TITLE
Bash command `start-dev.sh` fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Choose one of the following options:
 From the project root:
 
 ```bash
-./start-dev
+./start-dev.sh
 ```
 
 When finished, terminate all sessions with:
@@ -89,7 +89,7 @@ Sample test instances and their corresponding solution files can be found in the
 
 ---
 
-### Oficial Competition Validator
+### Official Competition Validator
 
 1. Navigate to the `validator` directory:
 


### PR DESCRIPTION
- This PR fixes the bash command to run the `start-dev.sh` script: the suffix of the file (`.sh`) was missing.
- Fixes a typo in README.md.